### PR TITLE
毛遂自荐 使用 @unisnips/ultisnips 解析 ultisnips 文本

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,12 @@
 			"integrity": "sha1-9l09Y4ngHutFi9VNyPUrlalGO8g=",
 			"dev": true
 		},
+		"@types/chai": {
+			"version": "4.2.7",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.7.tgz",
+			"integrity": "sha512-luq8meHGYwvky0O7u0eQZdA7B4Wd9owUCqvbw2m3XCrCU8mplYOujMBbvyS547AxJkC+pGnd0Cm15eNxEUNU8g==",
+			"dev": true
+		},
 		"@types/lodash": {
 			"version": "4.14.149",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
@@ -136,6 +142,12 @@
 				"color-convert": "^1.9.0"
 			}
 		},
+		"arg": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
+			"integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==",
+			"dev": true
+		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "http://registry.npm.taobao.org/argparse/download/argparse-1.0.10.tgz",
@@ -157,6 +169,12 @@
 			"version": "1.0.0",
 			"resolved": "http://registry.npm.taobao.org/assert-plus/download/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+		},
+		"assertion-error": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -220,6 +238,20 @@
 			"resolved": "http://registry.npm.taobao.org/caseless/download/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
+		"chai": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+			"integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+			"dev": true,
+			"requires": {
+				"assertion-error": "^1.1.0",
+				"check-error": "^1.0.2",
+				"deep-eql": "^3.0.1",
+				"get-func-name": "^2.0.0",
+				"pathval": "^1.1.0",
+				"type-detect": "^4.0.5"
+			}
+		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "http://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz",
@@ -230,6 +262,12 @@
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
 			}
+		},
+		"check-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"dev": true
 		},
 		"color-convert": {
 			"version": "1.9.3",
@@ -286,6 +324,15 @@
 			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
+			}
+		},
+		"deep-eql": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"dev": true,
+			"requires": {
+				"type-detect": "^4.0.0"
 			}
 		},
 		"delayed-stream": {
@@ -380,6 +427,12 @@
 			"version": "1.0.0",
 			"resolved": "http://registry.npm.taobao.org/fs.realpath/download/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"get-func-name": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
 			"dev": true
 		},
 		"getpass": {
@@ -549,6 +602,12 @@
 			"resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
 			"integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
 		},
+		"make-error": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+			"integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+			"dev": true
+		},
 		"mime-db": {
 			"version": "1.40.0",
 			"resolved": "https://registry.npm.taobao.org/mime-db/download/mime-db-1.40.0.tgz",
@@ -677,6 +736,12 @@
 			"version": "1.0.6",
 			"resolved": "http://registry.npm.taobao.org/path-parse/download/path-parse-1.0.6.tgz",
 			"integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+			"dev": true
+		},
+		"pathval": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
 			"dev": true
 		},
 		"performance-now": {
@@ -826,6 +891,27 @@
 				}
 			}
 		},
+		"ts-node": {
+			"version": "8.5.4",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
+			"integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
+			"dev": true,
+			"requires": {
+				"arg": "^4.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"source-map-support": "^0.5.6",
+				"yn": "^3.0.0"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+					"integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+					"dev": true
+				}
+			}
+		},
 		"tslib": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npm.taobao.org/tslib/download/tslib-1.10.0.tgz",
@@ -874,6 +960,12 @@
 			"version": "0.14.5",
 			"resolved": "http://registry.npm.taobao.org/tweetnacl/download/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+		},
+		"type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		},
 		"typescript": {
 			"version": "3.5.2",
@@ -943,6 +1035,12 @@
 			"version": "1.0.2",
 			"resolved": "http://registry.npm.taobao.org/wrappy/download/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
 			"dev": true
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "Vsnips",
-	"version": "0.1.0",
+	"version": "0.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -24,11 +24,29 @@
 				"js-tokens": "^4.0.0"
 			}
 		},
+		"@bestminr/control-flow": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@bestminr/control-flow/-/control-flow-0.1.0.tgz",
+			"integrity": "sha512-fvOrA1RCIWIFPdN+y9gbh71TIP/ib5sGrmMTNqZk6qE6qYLxDdrhj2qhFUAjwxXok/Nnv/vElatvpb8DPocJHg=="
+		},
 		"@types/caseless": {
 			"version": "0.12.2",
 			"resolved": "https://registry.npm.taobao.org/@types/caseless/download/@types/caseless-0.12.2.tgz",
 			"integrity": "sha1-9l09Y4ngHutFi9VNyPUrlalGO8g=",
 			"dev": true
+		},
+		"@types/lodash": {
+			"version": "4.14.149",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+			"integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
+		},
+		"@types/lodash.omit": {
+			"version": "4.5.6",
+			"resolved": "https://registry.npmjs.org/@types/lodash.omit/-/lodash.omit-4.5.6.tgz",
+			"integrity": "sha512-KXPpOSNX2h0DAG2w7ajpk7TXvWF28ZHs5nJhOJyP0BQHkehgr948RVsToItMme6oi0XJkp19CbuNXkIX8FiBlQ==",
+			"requires": {
+				"@types/lodash": "*"
+			}
 		},
 		"@types/mocha": {
 			"version": "2.2.48",
@@ -72,6 +90,22 @@
 			"resolved": "https://registry.npm.taobao.org/@types/tough-cookie/download/@types/tough-cookie-2.3.5.tgz",
 			"integrity": "sha1-naRO11VxmZtlw3tgybK4jbVMWF0=",
 			"dev": true
+		},
+		"@unisnips/core": {
+			"version": "0.2.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/@unisnips/core/-/core-0.2.0-alpha.0.tgz",
+			"integrity": "sha512-KQXmKK5HdpiGx+LXWuqNb9NDFUsa5qEnkv4pVlD8QW+RtCS1qH3epW1y/5tMnTZNeKkifmy16eq73krsr8tt9g=="
+		},
+		"@unisnips/ultisnips": {
+			"version": "0.2.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/@unisnips/ultisnips/-/ultisnips-0.2.0-alpha.0.tgz",
+			"integrity": "sha512-a3xZ5XRS/5Qo3f2rDrzFYW1gzfGv117OK/S5/pI287gO7Ebz2bkyUA+E49iHAtqFoI+tLp9rNXo7VnYmIHkirg==",
+			"requires": {
+				"@bestminr/control-flow": "^0.1.0",
+				"@types/lodash.omit": "*",
+				"@unisnips/core": "^0.2.0-alpha.0",
+				"lodash.omit": "^4.5.0"
+			}
 		},
 		"agent-base": {
 			"version": "4.3.0",
@@ -509,6 +543,11 @@
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
 			}
+		},
+		"lodash.omit": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+			"integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
 		},
 		"mime-db": {
 			"version": "1.40.0",

--- a/package.json
+++ b/package.json
@@ -98,8 +98,9 @@
 		"vscode": "^1.1.28"
 	},
 	"dependencies": {
-		"request": "^2.88.0",
-		"js-logger": "^1.6.0"
+		"@unisnips/ultisnips": "^0.2.0-alpha.0",
+		"js-logger": "^1.6.0",
+		"request": "^2.88.0"
 	},
 	"__metadata": {
 		"id": "a42f9b10-ee80-433b-9043-fc3a48ac1b2e",

--- a/package.json
+++ b/package.json
@@ -86,13 +86,13 @@
 		"test_base": "mocha -r ts-node/register ./src/test/**/*.spec.ts ./src/test/*.spec.ts"
 	},
 	"devDependencies": {
-		"@types/chai": "^4.2.5",
+		"@types/chai": "^4.2.7",
 		"@types/mocha": "^2.2.48",
 		"@types/node": "^10.12.21",
 		"@types/request": "^2.48.2",
 		"chai": "^4.2.0",
 		"mocha": "^6.2.2",
-		"ts-node": "^8.5.2",
+		"ts-node": "^8.5.4",
 		"tslint": "^5.12.1",
 		"typescript": "^3.3.1",
 		"vscode": "^1.1.28"

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -59,7 +59,7 @@ async function generate(context: vscode.ExtensionContext) {
             continue;
           }
           const data = fs.readFileSync(snipFile, "utf8");
-          await innerGenerate(data, fileType);
+          await innerGenerate(data, fileType, snipFile);
         }
       });
       // Add the doc snippets for current file type, a little ugly.
@@ -73,12 +73,14 @@ async function generate(context: vscode.ExtensionContext) {
   }
 
   // 主生成函数
-  async function innerGenerate(data: string, needFileType: string) {
+  async function innerGenerate(data: string, needFileType: string, snipFile?: string) {
     const sel: vscode.DocumentFilter = {
       scheme: "file",
       language: needFileType
     };
-    let snippets = await parse(data);
+    let snippets = await parse(data, {
+      snippetsFilePath: snipFile,
+    });
 
     let item = vscode.languages.registerCompletionItemProvider(
       sel, // 指定代码语言
@@ -110,6 +112,7 @@ async function generate(context: vscode.ExtensionContext) {
       "V",
       "v"
     );
+
     await context.subscriptions.push(item);
   }
 }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -65,9 +65,8 @@ function replacePlaceholderScript(snip: Snippet) {
       let replacement: PlaceholderReplacement | null = null;
       const { scriptInfo } = placeholder;
       if (scriptInfo) {
-        if (scriptInfo.scriptType === "js") {
-          snip.hasJSScript = true;
-        } else if (scriptInfo.scriptType === "python") {
+        snip.hasJSScript = true;
+        if (scriptInfo.scriptType === "python") {
           replacement = {
             placeholder,
             type: "string",

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -42,6 +42,7 @@ function parse(rawSnippets: string, opts: ParseOptions = {}): Array<Snippet> {
     snip.definition = def;
     snip.prefix = def.trigger;
     snip.body = def.body;
+    snip.descriptsion = def.description;
     replacePlaceholderScript(snip);
 
     Logger.debug("prefix: ", snip.prefix);

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,8 +1,8 @@
 import { Logger } from "./logger";
 import { VSnipContext } from "./vsnip_context";
 import * as ScriptFunc from "./script_tpl";
-import UNSNIPS_ULTISNIPS from '@unisnips/ultisnips';
-import { SnippetDefinition, applyReplacements, PlaceholderReplacement, ParseOptions } from '@unisnips/core';
+import UNSNIPS_ULTISNIPS from "@unisnips/ultisnips";
+import { SnippetDefinition, applyReplacements, PlaceholderReplacement, ParseOptions } from "@unisnips/core";
 
 class Snippet {
   prefix: string;
@@ -60,24 +60,24 @@ function replacePlaceholderScript(snip: Snippet) {
   // 全部找出后再一起替换.
   const replacements: PlaceholderReplacement[] = [];
 
-  snip.definition.placeholders.forEach((placeholder) => {
-    if (placeholder.valueType === 'script') {
+  snip.definition.placeholders.forEach(placeholder => {
+    if (placeholder.valueType === "script") {
       let replacement: PlaceholderReplacement | null = null;
       const { scriptInfo } = placeholder;
       if (scriptInfo) {
-        if (scriptInfo.scriptType === 'js') {
+        if (scriptInfo.scriptType === "js") {
           snip.hasJSScript = true;
-        } else if (scriptInfo.scriptType === 'python') {
+        } else if (scriptInfo.scriptType === "python") {
           replacement = {
             placeholder,
-            type: 'string',
-            replaceContent: pythonRewrite(scriptInfo.code),
+            type: "string",
+            replaceContent: pythonRewrite(scriptInfo.code)
           };
-        } else if (scriptInfo.scriptType === 'vim') {
+        } else if (scriptInfo.scriptType === "vim") {
           replacement = {
             placeholder,
-            type: 'string',
-            replaceContent: vimRewrite(scriptInfo.code),
+            type: "string",
+            replaceContent: vimRewrite(scriptInfo.code)
           };
         }
       }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,14 +1,15 @@
 import { Logger } from "./logger";
 import { VSnipContext } from "./vsnip_context";
 import * as ScriptFunc from "./script_tpl";
-import * as vscode from "vscode";
-
-const VIM_SNIPPET = /^snippet ([^\s]*)\s*(?:"(.*?)".*)?\n((?:.|\n)*?)\nendsnippet$/gm;
+import UNSNIPS_ULTISNIPS from '@unisnips/ultisnips';
+import { SnippetDefinition, applyReplacements, PlaceholderReplacement, ParseOptions } from '@unisnips/core';
 
 class Snippet {
   prefix: string;
   body: string;
   descriptsion: string;
+
+  definition!: SnippetDefinition;
 
   // 标记snip中是否有js函数, 如果有js占位函数的, 需要在补全时再进行一次求值操作
   // 将body体中的js函数进行求值处理.
@@ -32,104 +33,60 @@ class Snippet {
   }
 }
 
-function parse(rawSnippets: string): Array<Snippet> {
-  let res = null;
+function parse(rawSnippets: string, opts: ParseOptions = {}): Array<Snippet> {
   let snips: Array<Snippet> = [];
-  while ((res = VIM_SNIPPET.exec(rawSnippets)) !== null) {
-    const [_, prefix, description, body] = res;
-
-    let snip = new Snippet();
-    snip.prefix = prefix;
-    snip.body = normalizePlaceholders(body);
-    [snip.body, snip.hasJSScript] = lexParser(snip.body);
-    snip.descriptsion = description;
+  const { definitions } = UNSNIPS_ULTISNIPS.parse(rawSnippets, opts);
+  definitions.forEach(def => {
+    const snip = new Snippet();
+    snips.push(snip);
+    snip.definition = def;
+    snip.prefix = def.trigger;
+    snip.body = def.body;
+    replacePlaceholderScript(snip);
 
     Logger.debug("prefix: ", snip.prefix);
     Logger.debug("description: ", snip.descriptsion);
     Logger.debug("body: ", snip.body);
-    Logger.debug("hasJSScript: ", snip.hasJSScript);
-    snips.push(snip);
-  }
+  });
   return snips;
 }
 
 // 这部分代码用于实现从vim 或是 python函数 => js函数的转换
 // 主要应用了正则替换.
-function lexParser(str: string): [string, boolean] {
-  // 检查所有(``)包裹的部分, 并确保里面没有嵌套(`)
-  // 不允许多行包含多行
-  const SNIP_FUNC_PATTERN = /`([^\`]+)\`/g;
-
-  const FT_UNKNOW = 0x0;
-  const FT_VIM = 0x1;
-  const FT_PYTHON = 0x2;
-  const FT_JAVASCRIPT = 0x3;
-
-  Logger.debug("Before parse", str);
-  let rlt = "";
-  let hasJSScript = false;
-
+function replacePlaceholderScript(snip: Snippet) {
   // 记录需要替换的值, 最后统一替换, 这里一定要注意, 不要exec之后马上替换,
   // js的实现有问题, 直接替换会导致之后的匹配出现问题, 需要等到所有待替换的值
   // 全部找出后再一起替换.
-  let res = null;
-  let replaceMap = new Map();
+  const replacements: PlaceholderReplacement[] = [];
 
-  while ((res = SNIP_FUNC_PATTERN.exec(str)) !== null) {
-    let [stmt, func] = res as RegExpExecArray;
-    Logger.debug("Get parser", stmt);
-    if (replaceMap.get(stmt)) {
-      Logger.debug(`Already get ${stmt}.`);
-      continue;
+  snip.definition.placeholders.forEach((placeholder) => {
+    if (placeholder.valueType === 'script') {
+      let replacement: PlaceholderReplacement | null = null;
+      const { scriptInfo } = placeholder;
+      if (scriptInfo) {
+        if (scriptInfo.scriptType === 'js') {
+          snip.hasJSScript = true;
+        } else if (scriptInfo.scriptType === 'python') {
+          replacement = {
+            placeholder,
+            type: 'string',
+            replaceContent: pythonRewrite(scriptInfo.code),
+          };
+        } else if (scriptInfo.scriptType === 'vim') {
+          replacement = {
+            placeholder,
+            type: 'string',
+            replaceContent: vimRewrite(scriptInfo.code),
+          };
+        }
+      }
+      if (replacement) {
+        replacements.push(replacement);
+      }
     }
-
-    let func_type = FT_PYTHON;
-    if (func.startsWith("!p")) {
-      func_type = FT_PYTHON;
-    } else if (func.startsWith("!v")) {
-      func_type = FT_VIM;
-    } else if (func.startsWith("!js")) {
-      // TODO: make my own func
-      func_type = FT_JAVASCRIPT;
-      hasJSScript = true;
-    } else {
-      func_type = FT_UNKNOW;
-    }
-
-    switch (func_type) {
-      case FT_PYTHON:
-        rlt = pythonRewrite(func);
-        replaceMap.set(stmt, rlt);
-        break;
-      case FT_VIM:
-        rlt = vimRewrite(func);
-        replaceMap.set(stmt, rlt);
-        break;
-      case FT_JAVASCRIPT:
-        break;
-
-      default:
-        break;
-    }
-
-    Logger.debug("After replace stmt", stmt, "we got: ", str);
-  }
-
-  // string.replace函数调用一次只能替换一个, 需要全部替换
-  // Copy from: https://stackoverflow.com/a/55698996
-  function replaceAll(text: string, busca: string, reemplaza: string) {
-    while (text.toString().indexOf(busca) != -1)
-      text = text.toString().replace(busca, reemplaza);
-    return text;
-  }
-  replaceMap.forEach((rlt, stmt) => {
-    if (rlt.startsWith(`\`!js`)) {
-      hasJSScript = true;
-    }
-    str = replaceAll(str, stmt, rlt);
   });
 
-  return [str, hasJSScript];
+  snip.body = applyReplacements(snip.definition, replacements);
 }
 
 function pythonRewrite(stmt: string) {
@@ -193,18 +150,6 @@ function vimRewrite(stmt: string) {
   }
 
   return stmt;
-}
-
-function normalizePlaceholders(str: string) {
-  const visualPlaceholder = /\${(\d):\${VISUAL}}/;
-  if (visualPlaceholder.test(str)) {
-    let data = visualPlaceholder.exec(str) as RegExpExecArray;
-    const n = data[1];
-    Logger.debug("Get visual data", data, n);
-    return str.replace(visualPlaceholder, `$${n}`);
-  } else {
-    return str;
-  }
 }
 
 // 获得snip中的js函数, 并调用该函数名对应的函数指针.

--- a/syntaxes/snippets.json
+++ b/syntaxes/snippets.json
@@ -19,7 +19,7 @@
             "patterns": [
                 {
                     "name": "keyword.control",
-                    "match": "\\b(?i)(snippet|endsnippet|priority|global|endglobal)\\b"
+                    "match": "\\b(?i)(snippet|endsnippet|priority|global|endglobal|extends)\\b"
                 }
             ]
         },


### PR DESCRIPTION
先说好处：替换之后，能够增加 'extends' 的支持，之后的 priority 也可以很快加上。目前我本地打包了一个 vsix 自己用，parsing 部分没发现问题。

然后是前因后果 blahblah：

之前在 v2ex 上[问了一圈](https://www.v2ex.com/t/630497)发现没有轻量的方案，所以准备写一个 snippets 转换工具 [unisnips](https://github.com/hikerpig/unisnips)（发布了一个 node cli 程序，还没写文档。之后准备弄个 webapp），原意也是从想把自己常用的 ultisnips snippets 换到各种编辑器里原生的 snippet 格式。一开始也是觉得简单的正则匹配就够了，后来看了下 ultisnips 的文档和 honza 的 snippets，发现其实支持的语法还是稍微复杂一点，例如 tabstop 里还可以嵌套 (类似 `${1: return ${2: value}}`)，还有 transformation 之类高级功能。

我目前的思路是把 ultisnips 源码的 parsing 部分用 typescript 写一遍，导出一个中间格式的数据，供不同的 backend 使用。

看到你的项目觉得我们其实可以做得更多，port 一个 vscode 版的 ultisnips 也是可以的。

顺便说几个问题和提议:

问题：

1. 基于 completion item provider 的话，在选中一段文字的时候无法调出来 completion， 像 `$TM_SELECTED_TEXT` 这样的功能就没法用了。vscode 的 api 我不是很清楚，之前见人说需要选择一段以后调出 `editor.action.showSnippets` 这个 command，可以在保留选中状态的同时展开。感觉 Vsnips 也需要一个类似的 command ？
2. python script 的解释，不如考虑一下直接用一个外部的 python 程序执行一段拼出的代码，就不用用 js 再解析一遍 python 语句了，之前 ultisnips 里的 python 对象源码也可以直接用。但是的确这个可能工作量比较大。

提议：

1. 测试需要的 .vim 文件还是加到项目里 git 追踪好了，否则其他人一开始测试也不好跑起来